### PR TITLE
fixed borlndmm project

### DIFF
--- a/BorlndMM DLL/BorlndMM.dpr
+++ b/BorlndMM DLL/BorlndMM.dpr
@@ -18,7 +18,7 @@ Usage:
 library BorlndMM;
 
 uses
-  FastMM5,
+  FastMM5 in '..\FastMM5.pas',
   {System.SysUtils is needed for exception handling.}
   System.SysUtils;
 

--- a/BorlndMM DLL/BorlndMM.dproj
+++ b/BorlndMM DLL/BorlndMM.dproj
@@ -107,6 +107,7 @@
         <DelphiCompile Include="$(MainSource)">
             <MainSource>MainSource</MainSource>
         </DelphiCompile>
+        <DCCReference Include="..\FastMM5.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>


### PR DESCRIPTION
When trying to compile the borlndmm project without FastMM5 already being in the library path it fails.
I added the relative path to the file to fix this.