### PR TITLE
Fix debug block size overflow checks

### DIFF
--- a/FastMM5.pas
+++ b/FastMM5.pas
@@ -4097,6 +4097,26 @@ begin
   Result := CDebugBlockFooterCheckSumSize + AStackTraceDepth * (2 * SizeOf(Pointer));
 end;
 
+{Calculates the actual allocation size of a debug block, including the header and footer.  Returns false if the user
+size is negative or if the actual size calculation would overflow.}
+function TryCalculateDebugBlockSize(AUserSize: NativeInt; AStackTraceDepth: Byte;
+  out ADebugBlockSize: NativeInt): Boolean; inline;
+var
+  LDebugBlockOverhead: NativeInt;
+begin
+  Result := False;
+
+  if AUserSize < 0 then
+    Exit;
+
+  LDebugBlockOverhead := CDebugBlockHeaderSize + CalculateDebugBlockFooterSize(AStackTraceDepth);
+  if AUserSize > High(NativeInt) - LDebugBlockOverhead then
+    Exit;
+
+  ADebugBlockSize := AUserSize + LDebugBlockOverhead;
+  Result := True;
+end;
+
 procedure LogDebugBlockHeaderInvalid(APDebugBlockHeader: PFastMM_DebugBlockHeader);
 var
   LTokenValues: TEventLogTokenValues;
@@ -4477,7 +4497,7 @@ end;
 function FastMM_ReallocMem_ReallocDebugBlock(APointer: Pointer; ANewSize: NativeInt): Pointer;
 var
   LPActualBlock: PFastMM_DebugBlockHeader;
-  LAvailableSpace, LDebugFooterSize: NativeInt;
+  LAvailableSpace, LDebugBlockSize, LDebugFooterSize: NativeInt;
   LPOldFooter, LPNewFooter: Pointer;
 begin
   LPActualBlock := @PFastMM_DebugBlockHeader(APointer)[-1];
@@ -4489,7 +4509,10 @@ begin
   {Can the block be resized in-place?}
   LAvailableSpace := FastMM_BlockMaximumUserBytes(LPActualBlock);
   LDebugFooterSize := CalculateDebugBlockFooterSize(LPActualBlock.StackTraceEntryCount);
-  if LAvailableSpace >= (ANewSize + CDebugBlockHeaderSize + LDebugFooterSize) then
+  if not TryCalculateDebugBlockSize(ANewSize, LPActualBlock.StackTraceEntryCount, LDebugBlockSize) then
+    Exit(nil);
+
+  if LAvailableSpace >= LDebugBlockSize then
   begin
 
     {Avoid a potential race condition here:  While the debug header and footer is being updated the block must be flagged
@@ -4515,7 +4538,7 @@ begin
   else
   begin
     {The new size cannot fit in the existing block:  We need to allocate a new block.}
-    Result := FastMM_GetMem(ANewSize + CDebugBlockHeaderSize + LDebugFooterSize);
+    Result := FastMM_GetMem(LDebugBlockSize);
 
     if Result <> nil then
     begin
@@ -8029,12 +8052,16 @@ end;
 
 function FastMM_DebugGetMem_GetDebugBlock(ASize: NativeInt; AFillBlockWithDebugPattern: Boolean): Pointer;
 var
+  LDebugBlockSize: NativeInt;
   LStackTraceDepth: Byte;
 begin
   LStackTraceDepth := DebugMode_StackTrace_EntryCount;
 
   {Add the size of the debug header, footer checksum and two stack traces to the allocation size.}
-  Result := FastMM_GetMem(ASize + CDebugBlockHeaderSize + CalculateDebugBlockFooterSize(LStackTraceDepth));
+  if not TryCalculateDebugBlockSize(ASize, LStackTraceDepth, LDebugBlockSize) then
+    Exit(nil);
+
+  Result := FastMM_GetMem(LDebugBlockSize);
   if Result = nil then
     Exit;
 


### PR DESCRIPTION
## Summary

This is a second small follow-up PR from the same review pass as [#67](https://github.com/pleriche/FastMM5/pull/67).

The first PR fixed a debug-mode `AllocMem` header lookup issue. This PR addresses another debug-mode edge case: calculating the actual debug block size after adding header/footer overhead without first checking whether that size is representable in `NativeInt`.

The fix is intentionally limited to debug-mode allocation/reallocation paths.

## Problem

Debug-mode allocations add metadata around the user block:

- `CDebugBlockHeaderSize`
- debug footer checksum
- allocation stack trace
- free stack trace

The previous code added that overhead directly to the requested user size:

```pascal
ASize + CDebugBlockHeaderSize + CalculateDebugBlockFooterSize(...)
```

and debug `ReallocMem` used the same unchecked arithmetic when deciding whether the existing block could be resized in place:

```pascal
ANewSize + CDebugBlockHeaderSize + LDebugFooterSize
```

If the actual debug block size cannot be represented in `NativeInt`, the calculation can wrap before the normal allocator or realloc path sees the request.

The most important case is debug `ReallocMem`: a failed resize must leave the original block valid. With the unchecked in-place size test, an overflowed calculated size can make the code treat the existing block as large enough and mutate debug metadata, including `UserSize` and the debug footer location, before the request has been rejected.

## Fix

Add a small checked helper:

```pascal
TryCalculateDebugBlockSize(AUserSize, AStackTraceDepth, ADebugBlockSize)
```

It rejects debug block sizes that cannot be represented after adding header/footer overhead. The helper is used before:

- debug `GetMem` allocates a debug block
- debug `ReallocMem` checks whether a debug block can be resized in place
- debug `ReallocMem` allocates a replacement debug block

The change is intentionally limited to debug-mode paths.

## Reproducer

I kept the patch minimal and did not add a new test directory because the repository does not currently appear to have one. I can add this reproducer wherever you prefer.

Standalone reproducer:

```pascal
program DebugSizeOverflowRegression;

{$APPTYPE CONSOLE}

uses
  FastMM5,
  System.SysUtils;

procedure ExpectNil(APointer: Pointer; const AScenario: string);
begin
  if APointer <> nil then
    raise Exception.Create(AScenario + ' returned a non-nil pointer');
end;

procedure CheckDirectUnrepresentableAllocations;
begin
  {Negative sizes are invalid caller input, but they exercise the same guard:
  debug metadata must not be populated unless the full debug block size can be
  represented.}
  ExpectNil(FastMM_DebugGetMem(-1), 'FastMM_DebugGetMem(-1)');
  ExpectNil(FastMM_DebugAllocMem(-1), 'FastMM_DebugAllocMem(-1)');

  {This is the important positive-size case: the requested user size is a
  NativeInt value, but adding debug header/footer overhead would overflow the
  actual debug block size.}
  ExpectNil(FastMM_DebugGetMem(High(NativeInt)), 'FastMM_DebugGetMem(High(NativeInt))');
  ExpectNil(FastMM_DebugAllocMem(High(NativeInt)), 'FastMM_DebugAllocMem(High(NativeInt))');
end;

procedure CheckFailedReallocPreservesOldBlock(ANewSize: NativeInt; const AScenario: string);
var
  P: Pointer;
  Q: Pointer;
  I: Integer;
begin
  P := GetMemory(32);
  if P = nil then
    raise Exception.Create('Initial allocation failed');

  try
    FillChar(P^, 32, $5A);

    {The key ReallocMem contract is that failure leaves the old block valid.
    The buggy overflowed in-place size check could mutate UserSize and move the
    debug footer before failing.}
    Q := FastMM_DebugReallocMem(P, ANewSize);
    if Q <> nil then
      raise Exception.Create(AScenario + ' unexpectedly returned a non-nil pointer');

    {The old pointer must still be readable and later freeable after the failed
    resize request.}
    for I := 0 to 31 do
      if PByte(P)[I] <> $5A then
        raise Exception.CreateFmt('%s corrupted the old block at offset %d', [AScenario, I]);
  finally
    FreeMemory(P);
  end;
end;

begin
  ExitCode := 1;

  {The failure is specific to debug-mode wrappers that add header/footer
  overhead before calling the normal allocator. The full debug DLL is not
  required.}
  FastMM_EnterDebugMode;
  try
    CheckDirectUnrepresentableAllocations;
    {The negative-size ReallocMem case is an invalid-input boundary check.}
    CheckFailedReallocPreservesOldBlock(-1, 'FastMM_DebugReallocMem(-1)');
    {The positive-size ReallocMem case is the main overflow regression.}
    CheckFailedReallocPreservesOldBlock(High(NativeInt), 'FastMM_DebugReallocMem(High(NativeInt))');
  finally
    FastMM_ExitDebugMode;
  end;

  Writeln('OK: unrepresentable debug allocation and reallocation sizes failed cleanly.');
  ExitCode := 0;
end.
```

## Validation

Tested locally with RAD Studio 37.0:

- Win64 `dcc64`: build passed, reproducer passed
- Win32 `DCC32`: build passed, reproducer passed

Expected successful output:

```text
OK: unrepresentable debug allocation and reallocation sizes failed cleanly.
```

## Risk

Low. Normal-mode allocator paths are unchanged. The fix only adds validation before debug-mode code calculates actual debug block sizes or mutates debug metadata for a resize.
