### PR TITLE
Roll back mode-transition counters when the transition fails (#85)

### DIFF
--- a/FastMM5.pas
+++ b/FastMM5.pas
@@ -10915,7 +10915,12 @@ begin
     Inc(DebugModeCounter, ACounterAdjustment);
 
     if CurrentInstallationState <> mmisInstalled then
+    begin
+      {The transition cannot be performed:  Roll back the counter adjustment so that the counter stays consistent with
+      the actual mode state.  (See the note in AdjustEraseFreedBlockContentCounter.)}
+      Dec(DebugModeCounter, ACounterAdjustment);
       Exit(False);
+    end;
 
     {Does the current state match the counter?  If not, try to set the memory manager.}
     if (DebugModeCounter > 0) <> DebugModeActive then
@@ -10924,6 +10929,8 @@ begin
         FastMM_ConfigureDebugMode;
 
       Result := FastMM_SetMemoryManagerEntryPoints;
+      if not Result then
+        Dec(DebugModeCounter, ACounterAdjustment);
     end
     else
       Result := True;
@@ -10967,11 +10974,20 @@ begin
     Inc(EraseAllocatedBlockContentCounter, ACounterAdjustment);
 
     if CurrentInstallationState <> mmisInstalled then
+    begin
+      {The transition cannot be performed:  Roll back the counter adjustment so that the counter stays consistent with
+      the actual mode state.  (See the note in AdjustEraseFreedBlockContentCounter.)}
+      Dec(EraseAllocatedBlockContentCounter, ACounterAdjustment);
       Exit(False);
+    end;
 
     {Does the current state match the counter?  If not, try to set the memory manager.}
     if (EraseAllocatedBlockContentCounter > 0) <> EraseAllocatedBlockContentActive then
-      Result := FastMM_SetMemoryManagerEntryPoints
+    begin
+      Result := FastMM_SetMemoryManagerEntryPoints;
+      if not Result then
+        Dec(EraseAllocatedBlockContentCounter, ACounterAdjustment);
+    end
     else
       Result := True;
 
@@ -11002,11 +11018,22 @@ begin
     Inc(EraseFreedBlockContentCounter, ACounterAdjustment);
 
     if CurrentInstallationState <> mmisInstalled then
+    begin
+      {The transition cannot be performed:  Roll back the counter adjustment.  If the failed adjustment were retained,
+      the counter would no longer reflect the actual (unchanged) mode state, and since FastMM_SetMemoryManagerEntryPoints
+      derives the entry points and the *Active flags directly from the counters, a subsequent successful transition
+      (of this or another mode) would apply the wrong configuration and leave FastMM_EraseFreedBlockContentActive stuck.}
+      Dec(EraseFreedBlockContentCounter, ACounterAdjustment);
       Exit(False);
+    end;
 
     {Does the current state match the counter?  If not, try to set the memory manager.}
     if (EraseFreedBlockContentCounter > 0) <> EraseFreedBlockContentActive then
-      Result := FastMM_SetMemoryManagerEntryPoints
+    begin
+      Result := FastMM_SetMemoryManagerEntryPoints;
+      if not Result then
+        Dec(EraseFreedBlockContentCounter, ACounterAdjustment);
+    end
     else
       Result := True;
 


### PR DESCRIPTION
Follow-up to a6af62d for #85. That commit fixed the false-success result by deriving the active state from separate `*Active` flags, but a failed `Enter`/`Begin` call still leaves its adjustment in the nesting counter. Since `FastMM_SetMemoryManagerEntryPoints` builds both the entry points and the `*Active` flags directly from the counters, a later *successful* transition applies a configuration built from the poisoned count.

Concretely (janrysavy's reopen scenario): two `FastMM_BeginEraseFreedBlockContent` calls fail against an external manager and leave the counter at 2; a following balanced begin/end recovery pair then drives it 2->3->2, and because the state no longer matches, `FastMM_EraseFreedBlockContentActive` stays `True`. The contamination can even cross modes - a poisoned erase-freed counter turns a later successful `FastMM_EnterDebugMode` into one that also installs the erase-freed entry point.

This rolls back the counter adjustment on every failure path in all three `Adjust*Counter` helpers (installation not in the installed state, and `FastMM_SetMemoryManagerEntryPoints` returning `False`), while `SetMemoryManagerLock` is held - which is the rollback-under-lock behaviour the original report suggested.

Verified with 10 Seattle and 13.1 (Win32+Win64): all three modes roll back correctly, the cross-mode contamination case is gone, and normal nesting semantics (balanced and unbalanced begin/end without an external manager) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)