### PR TITLE
Improve contended Win64 small-block allocation with opt-in arena affinity

### DIFF
--- a/FastMM5.pas
+++ b/FastMM5.pas
@@ -1748,9 +1748,6 @@ const
 var
   {Lookup table for converting a block size to a small block type index from 0..CSmallBlockTypeCount - 1}
   SmallBlockTypeLookup: array[0.. CMaximumSmallBlockSize div CSmallBlockGranularity - 1] of Byte;
-{$ifdef FastMM_AdaptiveSmallBlockArenaAffinity}
-  ThreadArenaAffinityHasEntries: Byte;
-{$endif}
 
   {The small block managers.  Every arena has a separate manager for each small block size.  This should ideally be
   aligned on a 64-byte (cache line) boundary in order to prevent false dependencies between adjacent small block
@@ -1765,6 +1762,8 @@ var
   ThreadArenaAffinityEntries: array[0..CFastMM_ThreadArenaAffinitySlotCount - 1] of UInt64;
   {One bit per small-block type records which block sizes caused severe contention for the thread.}
   ThreadArenaAffinitySmallBlockTypeMasks: array[0..CFastMM_ThreadArenaAffinitySlotCount - 1] of UInt64;
+  {A nonzero entry enables the affinity lookup for the corresponding small-block type.}
+  ThreadArenaAffinityEnabledSmallBlockTypes: array[0..CSmallBlockTypeCount - 1] of Byte;
   ThreadArenaAffinityNextArena: Cardinal;
 {$endif}
 
@@ -4642,7 +4641,9 @@ asm
   {Publish the entry and mask together by returning the slot version to an even value.}
   lea r9, ThreadArenaAffinitySlotVersions
   lock inc dword ptr [r9 + r11 * 4]
-  mov byte ptr ThreadArenaAffinityHasEntries, 1
+  {Enable the lookup only for block types that have actually encountered severe contention.}
+  lea r9, ThreadArenaAffinityEnabledSmallBlockTypes
+  mov byte ptr [r9 + r8], 1
 end;
 {$endif}
 
@@ -7952,8 +7953,9 @@ asm
 {$ifdef FastMM_AdaptiveSmallBlockArenaAffinity}
   lea rdx, SmallBlockTypeLookup
   movzx ecx, byte ptr [rdx + rcx]
-  {Use the original arena order until at least one thread has encountered severe contention.}
-  cmp byte ptr ThreadArenaAffinityHasEntries, 0
+  {Use the original arena order until this block type has encountered severe contention.}
+  lea rdx, ThreadArenaAffinityEnabledSmallBlockTypes
+  cmp byte ptr [rdx + rcx], 0
   je @UseArenaZero
 
   {Only threads that have encountered contention on every arena use a stable starting arena.}

--- a/FastMM5.pas
+++ b/FastMM5.pas
@@ -8164,7 +8164,7 @@ asm
   mov eax, r8d
   and eax, (CBlockIsFreeFlag or CIsSmallBlockFlag)
   cmp eax, CIsSmallBlockFlag
-  je FastMM_ReallocMem_ReallocSmallBlock
+  je @SmallBlock
 
   mov eax, r8d
   and eax, (not CHasDebugInfoFlag)
@@ -8178,6 +8178,29 @@ asm
   je FastMM_ReallocMem_ReallocDebugBlock
 
   jmp HandleInvalidReallocMem
+
+@SmallBlock:
+  {Inline the common in-place small-block downsize path.  This avoids the compiler-generated frame and saved registers
+  in FastMM_ReallocMem_ReallocSmallBlock on Win64.}
+  mov r9d, r8d
+  and r9d, CDropSmallBlockFlagsMask
+  shl r9d, CSmallBlockSpanOffsetBitShift
+  mov rax, rcx
+  and rax, -CMediumBlockAlignment
+  sub rax, r9
+  mov rax, TSmallBlockSpanHeader(rax).SmallBlockManager
+  movzx r9d, TSmallBlockManager(rax).BlockSize
+  sub r9d, CSmallBlockHeaderSize
+
+  {Upsizes and large downsizes use the existing moving path.}
+  cmp r9, rdx
+  jb FastMM_ReallocMem_ReallocSmallBlock
+  lea r10, [rdx * 4 + CSmallBlockDownsizeCheckAdder]
+  cmp r10, r9
+  jb FastMM_ReallocMem_ReallocSmallBlock
+
+  mov rax, rcx
+  ret
 
 {$endif}
 {$else}

--- a/FastMM5.pas
+++ b/FastMM5.pas
@@ -977,6 +977,18 @@ function DebugLibrary_LogStackTrace_Legacy(APReturnAddresses: PNativeUInt; AMaxD
 
 implementation
 
+{Define FastMM_EnableAdaptiveSmallBlockArenaAffinity for adaptive per-thread arena affinity on Win64.  It is intended
+ for applications with severe small-block allocator contention.}
+{$if defined(FastMM_EnableAdaptiveSmallBlockArenaAffinity) and defined(MSWINDOWS) and defined(CPUX64)
+  and not defined(PurePascal)}
+  {$define FastMM_AdaptiveSmallBlockArenaAffinity}
+{$ifend}
+
+{$ifdef FastMM_AdaptiveSmallBlockArenaAffinity}
+const
+  CFastMM_ThreadArenaAffinitySlotCount = 256;
+{$endif}
+
 {All blocks are preceded by a block header.  The block header varies in size according to the block type.  The block
 type and state may be determined from the bits of the word preceding the block address, as follows:
 
@@ -1736,11 +1748,25 @@ const
 var
   {Lookup table for converting a block size to a small block type index from 0..CSmallBlockTypeCount - 1}
   SmallBlockTypeLookup: array[0.. CMaximumSmallBlockSize div CSmallBlockGranularity - 1] of Byte;
+{$ifdef FastMM_AdaptiveSmallBlockArenaAffinity}
+  ThreadArenaAffinityHasEntries: Byte;
+{$endif}
 
   {The small block managers.  Every arena has a separate manager for each small block size.  This should ideally be
   aligned on a 64-byte (cache line) boundary in order to prevent false dependencies between adjacent small block
   managers (RSP-28144).}
   SmallBlockManagers: TSmallBlockArenas;
+
+{$ifdef FastMM_AdaptiveSmallBlockArenaAffinity}
+  {Threads are entered into this table only after they encounter contention on every small-block arena.}
+  {Even slot versions are stable; an odd version means that the entry and mask are being updated.}
+  ThreadArenaAffinitySlotVersions: array[0..CFastMM_ThreadArenaAffinitySlotCount - 1] of Cardinal;
+  {The low 56 bits identify the live thread and the high 8 bits hold the assigned arena index plus one.}
+  ThreadArenaAffinityEntries: array[0..CFastMM_ThreadArenaAffinitySlotCount - 1] of UInt64;
+  {One bit per small-block type records which block sizes caused severe contention for the thread.}
+  ThreadArenaAffinitySmallBlockTypeMasks: array[0..CFastMM_ThreadArenaAffinitySlotCount - 1] of UInt64;
+  ThreadArenaAffinityNextArena: Cardinal;
+{$endif}
 
   {The default size of new medium block spans.  Must be a multiple of 64K and may not exceed CMaximumMediumBlockSpanSize.}
   DefaultMediumBlockSpanSize: Integer;
@@ -4540,6 +4566,85 @@ begin
   Inc(FastMM_SmallBlockThreadContentionCount);
   OS_AllowOtherThreadToRun;
 end;
+
+{$ifdef FastMM_AdaptiveSmallBlockArenaAffinity}
+{Enable small-block arena affinity for the current thread and block type after severe contention has been observed.}
+procedure EnableSmallBlockArenaAffinityForCurrentThread(ASmallBlockTypeIndex: Integer);
+asm
+  .noframe
+  mov r8d, ecx
+  mov edx, dword ptr gs:[$48]
+
+  {Combine the thread ID, stack base and TEB address so that a recycled thread ID cannot inherit a stale entry.}
+  mov r10, qword ptr gs:[$08]
+  shr r10, 16
+  mov r11, qword ptr gs:[$30]
+  shr r11, 12
+  xor r10d, r11d
+  xor r10d, edx
+  and r10d, $00ffffff
+  shl r10, 32
+  mov eax, edx
+  or r10, rax
+
+  mov eax, edx
+  shr eax, 2
+  and eax, CFastMM_ThreadArenaAffinitySlotCount - 1
+  mov r11d, eax
+
+  {Serialize all updates to a slot so that a colliding thread cannot publish an entry with another thread's mask.}
+  lea r9, ThreadArenaAffinitySlotVersions
+@AcquireSlot:
+  mov eax, [r9 + r11 * 4]
+  test al, 1
+  jnz @SlotBusy
+  lea edx, [eax + 1]
+  lock cmpxchg [r9 + r11 * 4], edx
+  jne @AcquireSlot
+  jmp @SlotAcquired
+@SlotBusy:
+  pause
+  jmp @AcquireSlot
+
+@SlotAcquired:
+  lea r9, ThreadArenaAffinityEntries
+  mov rax, [r9 + r11 * 8]
+  mov rdx, rax
+  shl rdx, 8
+  shr rdx, 8
+  cmp rdx, r10
+  je @SetSmallBlockType
+
+  {Assign activated threads evenly across all configured arenas.}
+  mov ecx, 1
+  lock xadd dword ptr ThreadArenaAffinityNextArena, ecx
+{$if (CFastMM_SmallBlockArenaCount = 4) or (CFastMM_SmallBlockArenaCount = 8) or (CFastMM_SmallBlockArenaCount = 16)}
+  and ecx, CFastMM_SmallBlockArenaCount - 1
+{$else}
+  mov eax, ecx
+  xor edx, edx
+  mov r9d, CFastMM_SmallBlockArenaCount
+  div r9d
+  mov ecx, edx
+{$ifend}
+  inc ecx
+  mov eax, ecx
+  shl rax, 56
+  or rax, r10
+  lea r9, ThreadArenaAffinitySmallBlockTypeMasks
+  mov qword ptr [r9 + r11 * 8], 0
+  lea r9, ThreadArenaAffinityEntries
+  mov [r9 + r11 * 8], rax
+
+@SetSmallBlockType:
+  lea r9, ThreadArenaAffinitySmallBlockTypeMasks
+  bts qword ptr [r9 + r11 * 8], r8
+  {Publish the entry and mask together by returning the slot version to an even value.}
+  lea r9, ThreadArenaAffinitySlotVersions
+  lock inc dword ptr [r9 + r11 * 4]
+  mov byte ptr ThreadArenaAffinityHasEntries, 1
+end;
+{$endif}
 
 procedure LogMediumBlockThreadContentionAndYieldToOtherThread;
 begin
@@ -7357,7 +7462,8 @@ end;
 
 {Tries to allocate a small block through the given small block manager.  If the manager has no available blocks, or
 it is locked, then the corresponding managers in other arenas are also tried.}
-function FastMM_GetMem_GetSmallBlock(APSmallBlockManager: PSmallBlockManager): Pointer;
+function FastMM_GetMem_GetSmallBlock(APSmallBlockManager: PSmallBlockManager
+  {$ifdef FastMM_AdaptiveSmallBlockArenaAffinity}; AStartArenaIndex: Integer{$endif}): Pointer;
 {$ifdef X86ASM}
 asm
   {--------------Attempt 1--------------
@@ -7486,9 +7592,22 @@ asm
   pop eax
   jmp @Attempt1Loop
 {$else}
+{$ifdef FastMM_AdaptiveSmallBlockArenaAffinity}
+var
+  LPFirstArenaSmallBlockManager, LPStartArenaSmallBlockManager: PSmallBlockManager;
+  LArenasVisited: Integer;
+{$endif}
 begin
+{$ifdef FastMM_AdaptiveSmallBlockArenaAffinity}
+  LPFirstArenaSmallBlockManager := APSmallBlockManager;
+  Dec(LPFirstArenaSmallBlockManager, CSmallBlockTypeCount * AStartArenaIndex);
+  LPStartArenaSmallBlockManager := APSmallBlockManager;
+{$endif}
   while True do
   begin
+{$ifdef FastMM_AdaptiveSmallBlockArenaAffinity}
+    APSmallBlockManager := LPStartArenaSmallBlockManager;
+{$endif}
 
     {--------------Attempt 1--------------
     Try to get a block from the first arena with an available block.  During the first attempt only memory that has
@@ -7500,6 +7619,9 @@ begin
       3) From the sequential feed span}
 
     {Walk the arenas for this small block type until we find an unlocked arena that can be used to obtain a block.}
+{$ifdef FastMM_AdaptiveSmallBlockArenaAffinity}
+    LArenasVisited := 0;
+{$endif}
     while True do
     begin
 
@@ -7539,14 +7661,28 @@ begin
       end;
 
       {Could not obtain a block from this arena:  Move on to the next arena.}
+{$ifdef FastMM_AdaptiveSmallBlockArenaAffinity}
+      Inc(LArenasVisited);
+      if LArenasVisited = CFastMM_SmallBlockArenaCount then
+        Break;
+      if NativeUInt(APSmallBlockManager) < NativeUInt(@SmallBlockManagers[CFastMM_SmallBlockArenaCount - 1]) then
+        Inc(APSmallBlockManager, CSmallBlockTypeCount)
+      else
+        APSmallBlockManager := LPFirstArenaSmallBlockManager;
+{$else}
       if NativeUInt(APSmallBlockManager) < NativeUInt(@SmallBlockManagers[CFastMM_SmallBlockArenaCount - 1]) then
         Inc(APSmallBlockManager, CSmallBlockTypeCount)
       else
         Break;
+{$endif}
 
     end;
     {Go back to the corresponding manager in the first arena}
+{$ifdef FastMM_AdaptiveSmallBlockArenaAffinity}
+    APSmallBlockManager := LPFirstArenaSmallBlockManager;
+{$else}
     Dec(APSmallBlockManager, CSmallBlockTypeCount * (CFastMM_SmallBlockArenaCount - 1));
+{$endif}
 
     {--------------Attempt 2--------------
     Lock the first unlocked arena and try again.  During the second attempt a new sequential feed span will be allocated
@@ -7595,11 +7731,18 @@ begin
       else
         Break;
     end;
+{$ifndef FastMM_AdaptiveSmallBlockArenaAffinity}
     Dec(APSmallBlockManager, CSmallBlockTypeCount * (CFastMM_SmallBlockArenaCount - 1));
+{$endif}
 
     {--------------Back off--------------
     All arenas are currently locked:  Back off and start again at the first arena}
 
+{$ifdef FastMM_AdaptiveSmallBlockArenaAffinity}
+    EnableSmallBlockArenaAffinityForCurrentThread(
+      (NativeUInt(LPFirstArenaSmallBlockManager) - NativeUInt(@SmallBlockManagers[0][0]))
+        shr CSmallBlockManagerSizeBits);
+{$endif}
     LogSmallBlockThreadContentionAndYieldToOtherThread;
 
   end;
@@ -7806,12 +7949,85 @@ asm
   {Small block:  Get the small block manager index in ecx}
   add ecx, 1
   shr ecx, CSmallBlockGranularityBits
+{$ifdef FastMM_AdaptiveSmallBlockArenaAffinity}
+  lea rdx, SmallBlockTypeLookup
+  movzx ecx, byte ptr [rdx + rcx]
+  {Use the original arena order until at least one thread has encountered severe contention.}
+  cmp byte ptr ThreadArenaAffinityHasEntries, 0
+  je @UseArenaZero
+
+  {Only threads that have encountered contention on every arena use a stable starting arena.}
+  mov edx, dword ptr gs:[$48]
+  cmp edx, System.MainThreadID
+  je @UseArenaZero
+
+  {Build the same live-thread key used when the entry was registered.}
+  mov r10, qword ptr gs:[$08]
+  shr r10, 16
+  mov r11, qword ptr gs:[$30]
+  shr r11, 12
+  xor r10d, r11d
+  xor r10d, edx
+  and r10d, $00ffffff
+  shl r10, 32
+  mov r11d, edx
+  or r10, r11
+
+  mov eax, edx
+  shr eax, 2
+  and eax, CFastMM_ThreadArenaAffinitySlotCount - 1
+  mov r9d, eax
+
+  {Read a consistent entry and block-type mask.  An update in progress falls back to arena 0.}
+  lea r8, ThreadArenaAffinitySlotVersions
+  mov edx, [r8 + r9 * 4]
+  test dl, 1
+  jnz @UseArenaZero
+
+  lea r8, ThreadArenaAffinityEntries
+  mov rax, [r8 + r9 * 8]
+  mov r11, rax
+  shl r11, 8
+  shr r11, 8
+  cmp r11, r10
+  jne @UseArenaZero
+
+  {Use the assigned arena only for block sizes on which this thread encountered severe contention.}
+  lea r8, ThreadArenaAffinitySmallBlockTypeMasks
+  bt qword ptr [r8 + r9 * 8], rcx
+  jnc @UseArenaZero
+
+  lea r11, ThreadArenaAffinitySlotVersions
+  cmp edx, [r11 + r9 * 4]
+  jne @UseArenaZero
+
+  shr rax, 56
+  test eax, eax
+  jz @UseArenaZero
+  dec eax
+  mov r8d, ecx
+  mov edx, eax
+  shl r8, CSmallBlockManagerSizeBits
+  imul r9, rdx, CSmallBlockManagerSize * CSmallBlockTypeCount
+  lea rcx, SmallBlockManagers
+  add rcx, r8
+  add rcx, r9
+  jmp FastMM_GetMem_GetSmallBlock
+
+@UseArenaZero:
+  {Get a pointer to the small block manager for arena 0 in rcx}
+  shl rcx, CSmallBlockManagerSizeBits
+  lea r8, SmallBlockManagers
+  add rcx, r8
+  xor edx, edx
+{$else}
   lea rdx, SmallBlockTypeLookup
   movzx ecx, byte ptr [rdx + rcx]
   {Get a pointer to the small block manager for arena 0 in rcx}
   shl rcx, CSmallBlockManagerSizeBits
   lea rdx, SmallBlockManagers
   add rcx, rdx
+{$endif}
   jmp FastMM_GetMem_GetSmallBlock
 @NotASmallBlock:
   cmp rcx, (CMaximumMediumBlockSize - CMediumBlockHeaderSize)


### PR DESCRIPTION
## Summary

FastMM5 currently starts every small-block arena search at arena 0. Under heavy allocator contention, worker threads repeatedly converge on the same first locks even when other arenas are available.

This change adds an opt-in Win64 path that gives a thread a stable starting arena for a block type after that thread has found every arena locked for that type. It improves the multithreaded speed score on both tested CPUs, while ordinary single-thread allocation becomes slightly slower. The feature therefore remains opt-in through `FastMM_EnableAdaptiveSmallBlockArenaAffinity`.

The candidate includes PR #98 plus affinity because that is the intended branch stack. The focused Raw Performance tests contain allocation and free without `ReallocMem`, so those checks exercise affinity rather than PR #98's reallocation fast path.

## Implementation

After severe contention, FastMM5 records a compact live-thread key, assigns an arena in round-robin order, and enables affinity only for the contended block type. Later allocations of that type start their first arena scan at the assigned arena and wrap once through all arenas. The second attempt still starts at arena 0, preserving the existing placement of new sequential-feed spans.

Affinity-table replacement is protected by per-slot odd/even versions, so colliding threads cannot publish one thread's key with another thread's type mask. Readers use affinity only when the version is unchanged and even. Missing, stale, or changing entries fall back to arena 0. A per-block-type activation bitmap keeps unrelated allocation sizes on the original fast path.

The implementation is limited to the Win64 assembler path. Win32 and `PurePascal` builds ignore the option.

## Benchmark and results

The benchmark is FastCodeBenchmark 3.0.2 at commit `990f66b4c74e461c0fecc567cf407f885b2604f5`, built for Win64 with Delphi 13.1 compiler version 37.0 and release optimization. It uses the normal latest Win64 selection and unchanged benchmark bodies, repeat counts, thread counts, and score weights. The [FastMM4-AVX documentation](https://github.com/maximmasiutin/FastMM4-AVX) refers to tests from the same [FastCodeBenchmark](https://github.com/maximmasiutin/FastCodeBenchmark) lineage.

The current benchmark no longer emits its historical graph score, so the companion `Score-Results.py` script applies that scoring model to the retained result rows: reciprocal elapsed ticks, normalization to the best of all five managers per benchmark, aggregation with the registered global weights, and group normalization. The result is then indexed to the Delphi RTL allocator at 100.00% for each CPU and group; higher is better. The table reports the elapsed-time speed component only. Peak memory and each benchmark's speed-versus-memory mix are evaluated separately and do not affect these columns. For example, 134.69% means a speed score 34.69% above RTL, not that every allocation is 134.69% faster.

### Methodology - complete current Fastcode Win64 default selection

The benchmark uses every test selected by the current Win64 startup rules: `RunByDefault` is true and `Is32BitSpecial` is false. The resulting 53-name selection includes individual allocation and reallocation operations, raw throughput, NexusDB, string and array workloads, and application-derived replays such as Webbroker and eLink. The single-thread column combines Fastcode's single-thread reallocation, allocation/free, and replay categories. Those benchmarks run before the threaded part of the suite, so the column describes pre-contention single-thread behavior; a separate same-process test below covers single-thread work after affinity has activated. Benchmark bodies and registered global weights are unchanged.

Fastcode calculates global weights for all `RunByDefault` benchmarks before Win64 startup unchecks `Is32BitSpecial` tests. Preserving those current rules makes multithread replays 68.10% of the selected multithread score instead of the category design's nominal 53.70%. This is a reproducible result for the current Win64 default selection rather than a platform-neutral overall ranking.

AMD Ryzen 9 7950X
| Memory manager | Single-thread RTL-relative speed score | Multithread RTL-relative speed score |
|---|---:|---:|
| Delphi 13.1 RTL | 100.00% | 100.00% |
| FastMM4 4.993 | 102.91% | 106.44% |
| FastMM4-AVX 1.0.12 | 97.84% | 48.46% |
| Upstream FastMM5 | 114.12% | 87.25% |
| **FastMM5 + PR #98 + affinity** | **112.32%** | **134.69%** |

Intel Core i7-8750H
| Memory manager | Single-thread RTL-relative speed score | Multithread RTL-relative speed score |
|---|---:|---:|
| Delphi 13.1 RTL | 100.00% | 100.00% |
| FastMM4 4.993 | 87.56% | 101.13% |
| FastMM4-AVX 1.0.12 | 85.82% | 74.79% |
| Upstream FastMM5 | 97.47% | 127.72% |
| **FastMM5 + PR #98 + affinity** | **97.20%** | **137.51%** |

The FastMM5 values use the median of three complete runs per benchmark, while Delphi RTL, FastMM4, and FastMM4-AVX each have one complete retained run per CPU and are orientation baselines only.

The primary patch comparison is the paired three-run FastMM5 result. Complete-suite multithread speed-score changes were +54.90%, +9.76%, and +14.84% on AMD, with a median of +14.84%, and +8.10%, +7.97%, and +7.72% on Intel, with a median of +7.97%. The improvement direction is consistent on both CPUs, while the AMD magnitude is workload- and run-sensitive. The per-benchmark-median table remains useful context but its larger AMD difference should not be read as the typical complete-run improvement.

Complete-suite single-thread speed-score changes were -1.10%, -1.25%, and -4.65% on AMD, with a median of -1.25%, and -1.00%, +0.41%, and -2.34% on Intel, with a median of -1.00%. A focused fresh Raw 1 check was effectively neutral: 0.72% faster on AMD and 0.65% slower on Intel by median elapsed time. After Raw 16 activated affinity in the same process, Raw 1 was 4.79% slower on AMD and 2.74% slower on Intel.

Focused full-duration checks supported the multithread conclusion. All AMD Raw 8/16/31/63 pairs were faster with affinity. On Intel, Raw 16/31/63 was faster in every pair, while Raw 8 was neutral. A separate 52-name historical-selector pair showed the same general tradeoff: higher multithreaded speed with a workload-dependent memory cost.

## Alternatives evaluated

Before selecting this implementation, I tested the following designs:

- Stable affinity was simple and fast, but distributed partly used spans across arenas and increased retained memory.
- Returning new-span allocation to arena 0 improved memory convergence but still applied affinity too broadly.
- Contention-triggered activation avoided uncontended work, but deriving the arena from thread-ID bits could cluster workers.
- Round-robin assignment distributed workers evenly, but the first affinity table could mistake a reused thread ID for a live entry.
- A stronger live-thread key fixed ID reuse, but thread-wide affinity still affected unrelated block types.
- Per-block-type activation fixed that scope problem and became part of the selected design.
- A separate wrapper could scan all arenas twice and caused a large multithreaded regression.
- Sharing the wrapper's second attempt removed the obvious double scan, but results depended on earlier benchmark state.
- Colocating the activation flag reduced cache traffic without fixing the wrapper's sequence dependence.
- Dynamic memory-manager entry-point switching proved unsafe.
- A marker in the block-size lookup weakened the useful multithreaded result.
- Separate normal and affinity scanners removed the fresh single-thread loss but still regressed single-thread work after affinity activation.

The selected opt-in design combines contention-triggered activation, round-robin assignment, a live-thread key, collision-safe publication, per-block-type state, and arena 0 convergence for new spans.

## Build and validation

The candidate passed the regular Fastcode validation suite and a 24-worker contention-then-validation run. It also passed that sequence with five arenas, compiled with 16 arenas, and passed a one-slot collision stress build followed by Validation 24. Win32 default, Win32 with the option symbol, and Win64 `PurePascal` compile checks succeeded.

## Reproduction

Build upstream FastMM5 at `1a6fb17e4ed525a52c6399ab3e57c7e11ca4d3a3`. For the candidate, apply PR #98 rebased as `c291b2890075e2d616e86ed7b284b5eba248cf26`, then the affinity commits through `49b52fc360238a1ac475b6e4ff7100c47c3dbc37`, and define `FastMM_EnableAdaptiveSmallBlockArenaAffinity`.

Build FastCodeBenchmark commit `990f66b4c74e461c0fecc567cf407f885b2604f5` with Delphi 13.1 Win64 release optimization. Run the normal selection from a directory containing the supplied replay traces. Run each allocator in a fresh process and retain the raw ticks, peak KiB, completion record, and exit code.

## Scope

This option is intended for Win64 applications with severe small-block allocator contention. It is not a general replacement for the normal allocation path. Applications that do not accept the small single-thread cost can leave the option undefined.
